### PR TITLE
Allow semantic versions to have optional minor and patch numbers

### DIFF
--- a/src/main/scala/nl/biopet/utils/SemanticVersion.scala
+++ b/src/main/scala/nl/biopet/utils/SemanticVersion.scala
@@ -73,13 +73,6 @@ object SemanticVersion {
     */
   def canParse(version: String): Boolean = fromString(version).isDefined
 
-  def digitToOptionInt(digit: String): Option[Int] = {
-    digit match {
-      case "" => None
-      case _ => Some(digit.toInt)
-    }
-  }
-
   /**
     * Check whether a version string is a semantic version.
     * Note: the toInt calls here are only safe because the regex only matches numbers
@@ -92,9 +85,10 @@ object SemanticVersion {
       case semanticVersionRegex(major, minor, patch, build) =>
         Some(
           SemanticVersion(major.toInt,
-            digitToOptionInt(minor.stripPrefix("\\.")),
-                          digitToOptionInt(patch.stripPrefix("\\.")),
-                          Option(build).map(x => x.stripPrefix("-"))))
+                          Option(minor).map(x => x.stripPrefix(".").toInt),
+                          Option(patch).map(x => x.stripPrefix(".").toInt),
+                          Option(build).map(x => x.stripPrefix("-")))
+        )
       case _ => None
     }
   }

--- a/src/main/scala/nl/biopet/utils/SemanticVersion.scala
+++ b/src/main/scala/nl/biopet/utils/SemanticVersion.scala
@@ -20,7 +20,6 @@
  */
 
 package nl.biopet.utils
-import scala.math.Ordered.orderingToOrdered
 import scala.util.matching.Regex
 
 /**
@@ -39,6 +38,12 @@ case class SemanticVersion(major: Int,
     this.build == that.build
   }
 
+  /**
+    * Compare two Option[Int] values.
+    * @param x an Option[Int]
+    * @param y the other Option[Int]
+    * @return Comparator Int.
+    */
   def compareOptionInt(x: Option[Int], y: Option[Int]): Int = {
     (x, y) match {
       case (Some(_), None)    => +1 //Some(number) is always better than None
@@ -55,8 +60,8 @@ case class SemanticVersion(major: Int,
     * Versions without builds (no -alpha, -SNAPSHOT or -build123)
     * are assumed to be later than versions with builds.
     * Example 0.8.0-alpha < 0.8.0-beta < 0.8.0
-    * @param that
-    * @return
+    * @param that another SemanticVersion
+    * @return Comparator int
     */
   def compare(that: SemanticVersion): Int = {
     val majorCompare = this.major compare that.major

--- a/src/main/scala/nl/biopet/utils/SemanticVersion.scala
+++ b/src/main/scala/nl/biopet/utils/SemanticVersion.scala
@@ -27,8 +27,8 @@ import scala.util.matching.Regex
   * Created by pjvanthof on 29/04/2017.
   */
 case class SemanticVersion(major: Int,
-                           minor: Option[Int],
-                           patch: Option[Int],
+                           minor: Option[Int] = None,
+                           patch: Option[Int] = None,
                            build: Option[String] = None)
     extends Ordered[SemanticVersion] {
 
@@ -63,7 +63,7 @@ case class SemanticVersion(major: Int,
 }
 
 object SemanticVersion {
-  val semanticVersionRegex: Regex = "[vV]?(\\d+)\\.(\\d+)\\.(\\d+)(-.*)?".r
+  val semanticVersionRegex: Regex = "[vV]?(\\d+)\\.?(\\d+)\\.?(\\d+)(-.*)?".r
 
   /**
     * Check whether a version string is a semantic version.
@@ -85,8 +85,8 @@ object SemanticVersion {
       case semanticVersionRegex(major, minor, patch, build) =>
         Some(
           SemanticVersion(major.toInt,
-                          minor.toInt,
-                          patch.toInt,
+                          Some(minor.toInt),
+                          Some(patch.toInt),
                           Option(build).map(x => x.stripPrefix("-"))))
       case _ => None
     }

--- a/src/main/scala/nl/biopet/utils/SemanticVersion.scala
+++ b/src/main/scala/nl/biopet/utils/SemanticVersion.scala
@@ -63,7 +63,7 @@ case class SemanticVersion(major: Int,
 }
 
 object SemanticVersion {
-  val semanticVersionRegex: Regex = "[vV]?(\\d+)\\.?(\\d+)\\.?(\\d+)(-.*)?".r
+  val semanticVersionRegex: Regex = "^[vV]?(\\d+)(\\.\\d+)?(\\.\\d+)?(-.*)?".r
 
   /**
     * Check whether a version string is a semantic version.
@@ -72,6 +72,13 @@ object SemanticVersion {
     * @return boolean
     */
   def canParse(version: String): Boolean = fromString(version).isDefined
+
+  def digitToOptionInt(digit: String): Option[Int] = {
+    digit match {
+      case "" => None
+      case _ => Some(digit.toInt)
+    }
+  }
 
   /**
     * Check whether a version string is a semantic version.
@@ -85,8 +92,8 @@ object SemanticVersion {
       case semanticVersionRegex(major, minor, patch, build) =>
         Some(
           SemanticVersion(major.toInt,
-                          Some(minor.toInt),
-                          Some(patch.toInt),
+            digitToOptionInt(minor.stripPrefix("\\.")),
+                          digitToOptionInt(patch.stripPrefix("\\.")),
                           Option(build).map(x => x.stripPrefix("-"))))
       case _ => None
     }

--- a/src/main/scala/nl/biopet/utils/SemanticVersion.scala
+++ b/src/main/scala/nl/biopet/utils/SemanticVersion.scala
@@ -27,8 +27,8 @@ import scala.util.matching.Regex
   * Created by pjvanthof on 29/04/2017.
   */
 case class SemanticVersion(major: Int,
-                           minor: Int,
-                           patch: Int,
+                           minor: Option[Int],
+                           patch: Option[Int],
                            build: Option[String] = None)
     extends Ordered[SemanticVersion] {
 

--- a/src/test/scala/nl/biopet/utils/SemanticVersionTest.scala
+++ b/src/test/scala/nl/biopet/utils/SemanticVersionTest.scala
@@ -80,7 +80,8 @@ class SemanticVersionTest extends BiopetTest {
     fromString(semanticVersion).flatMap(_.build) shouldBe None
     fromString(semanticVersionWith1).flatMap(_.build) shouldBe None
     fromString(semanticVersionWith2).flatMap(_.build) shouldBe None
-    fromString(semanticVersionWith2AndBuild).flatMap(_.build) shouldBe Some("SNAPSHOT")
+    fromString(semanticVersionWith2AndBuild).flatMap(_.build) shouldBe Some(
+      "SNAPSHOT")
     fromString(semanticVersionWithBuild).flatMap(_.build) shouldBe Some(
       "alpha0.1")
   }
@@ -143,18 +144,21 @@ class SemanticVersionTest extends BiopetTest {
   }
   @Test
   def testSort(): Unit = {
-    val versions = Seq("v1.0.3", "2.3.3", "0.8.0", "0.8.0-alpha","v3.0", "0.8.0-beta")
+    val versions =
+      Seq("v1.0.3", "2.3.3", "0.8.0", "0.8.0-alpha", "v3.0", "0.8.0-beta")
     val sortedVersions = versions.sortBy(version =>
       fromString(version) match {
         case Some(semVer) => semVer
-        case _            => new SemanticVersion(0)
+        case _ =>
+          throw new IllegalStateException(
+            "Test numbers should be parsable by semver.")
     })
     sortedVersions shouldBe Seq("0.8.0-alpha",
                                 "0.8.0-beta",
                                 "0.8.0",
                                 "v1.0.3",
                                 "2.3.3",
-    "3.0")
+                                "3.0")
   }
 
   def testBigVersionSort(): Unit = {
@@ -170,7 +174,9 @@ class SemanticVersionTest extends BiopetTest {
     val sortedVersions = versions.sortBy(version =>
       fromString(version) match {
         case Some(semVer) => semVer
-        case _            => new SemanticVersion(0)
+        case _ =>
+          throw new IllegalStateException(
+            "Test numbers should be parsable by semver.")
     })
     sortedVersions shouldBe Seq(
       "2.82312123213.31231-XYZbladsa",
@@ -181,5 +187,4 @@ class SemanticVersionTest extends BiopetTest {
       s"${Int.MaxValue + 20}.1.1"
     )
   }
-
 }

--- a/src/test/scala/nl/biopet/utils/SemanticVersionTest.scala
+++ b/src/test/scala/nl/biopet/utils/SemanticVersionTest.scala
@@ -93,6 +93,13 @@ class SemanticVersionTest extends BiopetTest {
   }
 
   @Test
+  def testMixedDigits(): Unit = {
+    fromString("2") > fromString("1.1") shouldBe true
+    fromString("1.1") < fromString("1.1.1") shouldBe true
+    fromString("1.1-SNAPSHOT") < fromString("1.1") shouldBe true
+  }
+
+  @Test
   def testLesserThen(): Unit = {
     SemanticVersion(1, 1, 1) < SemanticVersion(1, 1, 1) shouldBe false
     SemanticVersion(1, 1, 1) < SemanticVersion(0, 1, 1) shouldBe false
@@ -101,6 +108,7 @@ class SemanticVersionTest extends BiopetTest {
     SemanticVersion(1, 1, 1) < SemanticVersion(2, 1, 1) shouldBe true
     SemanticVersion(1, 1, 1) < SemanticVersion(1, 2, 1) shouldBe true
     SemanticVersion(1, 1, 1) < SemanticVersion(1, 1, 2) shouldBe true
+    SemanticVersion(1, 1, 1) < SemanticVersion(1, 1, 1, Some("SNAP")) shouldBe true
   }
 
   @Test

--- a/src/test/scala/nl/biopet/utils/SemanticVersionTest.scala
+++ b/src/test/scala/nl/biopet/utils/SemanticVersionTest.scala
@@ -87,7 +87,22 @@ class SemanticVersionTest extends BiopetTest {
   }
 
   @Test
+  def testEquals(): Unit = {
+    new SemanticVersion(1) == new SemanticVersion(1) shouldBe true
+    new SemanticVersion(1,Some(1)) == new SemanticVersion(1, Some(1)) shouldBe true
+    new SemanticVersion(1,Some(1),Some(1)) == new SemanticVersion(1,Some(1),Some(1)) shouldBe true
+    new SemanticVersion(1,build = Some("SNAPSHOT")) == new SemanticVersion(1,build = Some("SNAPSHOT")) shouldBe true
+
+    new SemanticVersion(2) == new SemanticVersion(1) shouldBe false
+    new SemanticVersion(1,Some(2)) == new SemanticVersion(1, Some(1)) shouldBe false
+    new SemanticVersion(1,Some(1),Some(2)) == new SemanticVersion(1,Some(1),Some(1)) shouldBe false
+    new SemanticVersion(1,build = Some("alpha")) == new SemanticVersion(1,build = Some("SNAPSHOT")) shouldBe false
+
+  }
+  @Test
   def testGreaterThen(): Unit = {
+    fromString("1.1") > (fromString("1")) shouldBe true
+    fromString("1.0") > fromString("1.0.3") shouldBe false
     fromString("1.1.1") > fromString("1.1.1") shouldBe false
     fromString("1.1.1") > fromString("0.1.1") shouldBe true
     fromString("1.1.1") > fromString("1.0.1") shouldBe true

--- a/src/test/scala/nl/biopet/utils/SemanticVersionTest.scala
+++ b/src/test/scala/nl/biopet/utils/SemanticVersionTest.scala
@@ -59,20 +59,20 @@ class SemanticVersionTest extends BiopetTest {
 
   @Test
   def testMinorVersion(): Unit = {
-    fromString(semanticVersion).map(_.minor) shouldBe Some(2)
-    fromString(semanticVersionWith1).map(_.minor) shouldBe Some(2)
-    fromString(semanticVersionWith2).map(_.minor) shouldBe Some(2)
-    fromString(semanticVersionWith2AndBuild).map(_.major) shouldBe Some(2)
-    fromString(semanticVersionWithBuild).map(_.minor) shouldBe Some(2)
+    fromString(semanticVersion).map(_.minor) shouldBe Some(Some(2))
+    fromString(semanticVersionWith1).map(_.minor) shouldBe Some(None)
+    fromString(semanticVersionWith2).map(_.minor) shouldBe Some(Some(2))
+    fromString(semanticVersionWith2AndBuild).map(_.minor) shouldBe Some(Some(2))
+    fromString(semanticVersionWithBuild).map(_.minor) shouldBe Some(Some(2))
   }
 
   @Test
   def testPatchVersion(): Unit = {
-    fromString(semanticVersion).map(_.patch) shouldBe Some(3)
-    fromString(semanticVersionWith1).map(_.patch) shouldBe Some(3)
-    fromString(semanticVersionWith2).map(_.patch) shouldBe Some(3)
-    fromString(semanticVersionWith2AndBuild).map(_.major) shouldBe None
-    fromString(semanticVersionWithBuild).map(_.patch) shouldBe Some(3)
+    fromString(semanticVersion).map(_.patch) shouldBe Some(Some(3))
+    fromString(semanticVersionWith1).map(_.patch) shouldBe Some(None)
+    fromString(semanticVersionWith2).map(_.patch) shouldBe Some(None)
+    fromString(semanticVersionWith2AndBuild).map(_.patch) shouldBe Some(None)
+    fromString(semanticVersionWithBuild).map(_.patch) shouldBe Some(Some(3))
   }
 
   @Test
@@ -113,7 +113,7 @@ class SemanticVersionTest extends BiopetTest {
     fromString("1.1.1") < fromString("2.1.1") shouldBe true
     fromString("1.1.1") < fromString("1.2.1") shouldBe true
     fromString("1.1.1") < fromString("1.1.2") shouldBe true
-    fromString("1.1.1") < fromString("1.1.1-SNAPSHOT") shouldBe true
+    fromString("1.1.1") < fromString("1.1.1-SNAPSHOT") shouldBe false
   }
 
   @Test
@@ -158,7 +158,7 @@ class SemanticVersionTest extends BiopetTest {
                                 "0.8.0",
                                 "v1.0.3",
                                 "2.3.3",
-                                "3.0")
+                                "v3.0")
   }
 
   def testBigVersionSort(): Unit = {

--- a/src/test/scala/nl/biopet/utils/SemanticVersionTest.scala
+++ b/src/test/scala/nl/biopet/utils/SemanticVersionTest.scala
@@ -111,7 +111,7 @@ class SemanticVersionTest extends BiopetTest {
   }
   @Test
   def testGreaterThen(): Unit = {
-    fromString("1.1") > (fromString("1")) shouldBe true
+    fromString("1.1") > fromString("1") shouldBe true
     fromString("1.0") > fromString("1.0.3") shouldBe false
     fromString("1.1.1") > fromString("1.1.1") shouldBe false
     fromString("1.1.1") > fromString("0.1.1") shouldBe true

--- a/src/test/scala/nl/biopet/utils/SemanticVersionTest.scala
+++ b/src/test/scala/nl/biopet/utils/SemanticVersionTest.scala
@@ -32,11 +32,11 @@ import org.testng.annotations.Test
 class SemanticVersionTest extends BiopetTest {
 
   val semanticVersion = "1.2.3"
-  val semanticVersionWith1 = "v1.2.3"
-  val semanticVersionWith2 = "V1.2.3"
+  val semanticVersionWith1 = "v1"
+  val semanticVersionWith2 = "V1.2"
+  val semanticVersionWith2AndBuild = "v1.2-SNAPSHOT"
   val semanticVersionWithBuild = "1.2.3-alpha0.1"
   val nonSemanticVersion = "v1222.1"
-
   @Test
   def testIsSemantic(): Unit = {
     canParse(semanticVersion) shouldBe true
@@ -49,6 +49,7 @@ class SemanticVersionTest extends BiopetTest {
     fromString(semanticVersion).map(_.major) shouldBe Some(1)
     fromString(semanticVersionWith1).map(_.major) shouldBe Some(1)
     fromString(semanticVersionWith2).map(_.major) shouldBe Some(1)
+    fromString(semanticVersionWith2AndBuild).map(_.major) shouldBe Some(1)
     fromString(semanticVersionWithBuild).map(_.major) shouldBe Some(1)
   }
 
@@ -57,6 +58,7 @@ class SemanticVersionTest extends BiopetTest {
     fromString(semanticVersion).map(_.minor) shouldBe Some(2)
     fromString(semanticVersionWith1).map(_.minor) shouldBe Some(2)
     fromString(semanticVersionWith2).map(_.minor) shouldBe Some(2)
+    fromString(semanticVersionWith2AndBuild).map(_.major) shouldBe Some(2)
     fromString(semanticVersionWithBuild).map(_.minor) shouldBe Some(2)
   }
 
@@ -65,6 +67,7 @@ class SemanticVersionTest extends BiopetTest {
     fromString(semanticVersion).map(_.patch) shouldBe Some(3)
     fromString(semanticVersionWith1).map(_.patch) shouldBe Some(3)
     fromString(semanticVersionWith2).map(_.patch) shouldBe Some(3)
+    fromString(semanticVersionWith2AndBuild).map(_.major) shouldBe None
     fromString(semanticVersionWithBuild).map(_.patch) shouldBe Some(3)
   }
 
@@ -73,6 +76,7 @@ class SemanticVersionTest extends BiopetTest {
     fromString(semanticVersion).flatMap(_.build) shouldBe None
     fromString(semanticVersionWith1).flatMap(_.build) shouldBe None
     fromString(semanticVersionWith2).flatMap(_.build) shouldBe None
+    fromString(semanticVersionWith2AndBuild).flatMap(_.build) shouldBe Some("SNAPSHOT")
     fromString(semanticVersionWithBuild).flatMap(_.build) shouldBe Some(
       "alpha0.1")
   }

--- a/src/test/scala/nl/biopet/utils/SemanticVersionTest.scala
+++ b/src/test/scala/nl/biopet/utils/SemanticVersionTest.scala
@@ -89,14 +89,24 @@ class SemanticVersionTest extends BiopetTest {
   @Test
   def testEquals(): Unit = {
     new SemanticVersion(1) == new SemanticVersion(1) shouldBe true
-    new SemanticVersion(1,Some(1)) == new SemanticVersion(1, Some(1)) shouldBe true
-    new SemanticVersion(1,Some(1),Some(1)) == new SemanticVersion(1,Some(1),Some(1)) shouldBe true
-    new SemanticVersion(1,build = Some("SNAPSHOT")) == new SemanticVersion(1,build = Some("SNAPSHOT")) shouldBe true
+    new SemanticVersion(1, Some(1)) == new SemanticVersion(1, Some(1)) shouldBe true
+    new SemanticVersion(1, Some(1), Some(1)) == new SemanticVersion(
+      1,
+      Some(1),
+      Some(1)) shouldBe true
+    new SemanticVersion(1, build = Some("SNAPSHOT")) == new SemanticVersion(
+      1,
+      build = Some("SNAPSHOT")) shouldBe true
 
     new SemanticVersion(2) == new SemanticVersion(1) shouldBe false
-    new SemanticVersion(1,Some(2)) == new SemanticVersion(1, Some(1)) shouldBe false
-    new SemanticVersion(1,Some(1),Some(2)) == new SemanticVersion(1,Some(1),Some(1)) shouldBe false
-    new SemanticVersion(1,build = Some("alpha")) == new SemanticVersion(1,build = Some("SNAPSHOT")) shouldBe false
+    new SemanticVersion(1, Some(2)) == new SemanticVersion(1, Some(1)) shouldBe false
+    new SemanticVersion(1, Some(1), Some(2)) == new SemanticVersion(
+      1,
+      Some(1),
+      Some(1)) shouldBe false
+    new SemanticVersion(1, build = Some("alpha")) == new SemanticVersion(
+      1,
+      build = Some("SNAPSHOT")) shouldBe false
 
   }
   @Test

--- a/src/test/scala/nl/biopet/utils/SemanticVersionTest.scala
+++ b/src/test/scala/nl/biopet/utils/SemanticVersionTest.scala
@@ -36,10 +36,14 @@ class SemanticVersionTest extends BiopetTest {
   val semanticVersionWith2 = "V1.2"
   val semanticVersionWith2AndBuild = "v1.2-SNAPSHOT"
   val semanticVersionWithBuild = "1.2.3-alpha0.1"
-  val nonSemanticVersion = "v1222.1"
+  val nonSemanticVersion = "dasd.wje29.ds"
+
   @Test
   def testIsSemantic(): Unit = {
     canParse(semanticVersion) shouldBe true
+    canParse(semanticVersionWith1) shouldBe true
+    canParse(semanticVersionWith2) shouldBe true
+    canParse(semanticVersionWith2AndBuild) shouldBe true
     canParse(semanticVersionWithBuild) shouldBe true
     canParse(nonSemanticVersion) shouldBe false
   }

--- a/src/test/scala/nl/biopet/utils/SemanticVersionTest.scala
+++ b/src/test/scala/nl/biopet/utils/SemanticVersionTest.scala
@@ -139,7 +139,7 @@ class SemanticVersionTest extends BiopetTest {
   }
   @Test
   def testSort(): Unit = {
-    val versions = Seq("v1.0.3", "2.3.3", "0.8.0", "0.8.0-alpha", "0.8.0-beta")
+    val versions = Seq("v1.0.3", "2.3.3", "0.8.0", "0.8.0-alpha","v3.0", "0.8.0-beta")
     val sortedVersions = versions.sortBy(version =>
       fromString(version) match {
         case Some(semVer) => semVer
@@ -149,7 +149,8 @@ class SemanticVersionTest extends BiopetTest {
                                 "0.8.0-beta",
                                 "0.8.0",
                                 "v1.0.3",
-                                "2.3.3")
+                                "2.3.3",
+    "3.0")
   }
 
   def testBigVersionSort(): Unit = {

--- a/src/test/scala/nl/biopet/utils/SemanticVersionTest.scala
+++ b/src/test/scala/nl/biopet/utils/SemanticVersionTest.scala
@@ -83,13 +83,13 @@ class SemanticVersionTest extends BiopetTest {
 
   @Test
   def testGreaterThen(): Unit = {
-    SemanticVersion(1, 1, 1) > SemanticVersion(1, 1, 1) shouldBe false
-    SemanticVersion(1, 1, 1) > SemanticVersion(0, 1, 1) shouldBe true
-    SemanticVersion(1, 1, 1) > SemanticVersion(1, 0, 1) shouldBe true
-    SemanticVersion(1, 1, 1) > SemanticVersion(1, 1, 0) shouldBe true
-    SemanticVersion(1, 1, 1) > SemanticVersion(2, 1, 1) shouldBe false
-    SemanticVersion(1, 1, 1) > SemanticVersion(1, 2, 1) shouldBe false
-    SemanticVersion(1, 1, 1) > SemanticVersion(1, 1, 2) shouldBe false
+    fromString("1.1.1") > fromString("1.1.1") shouldBe false
+    fromString("1.1.1") > fromString("0.1.1") shouldBe true
+    fromString("1.1.1") > fromString("1.0.1") shouldBe true
+    fromString("1.1.1") > fromString("1.1.0") shouldBe true
+    fromString("1.1.1") > fromString("2.1.1") shouldBe false
+    fromString("1.1.1") > fromString("1.2.1") shouldBe false
+    fromString("1.1.1") > fromString("1.1.2") shouldBe false
   }
 
   @Test
@@ -101,41 +101,41 @@ class SemanticVersionTest extends BiopetTest {
 
   @Test
   def testLesserThen(): Unit = {
-    SemanticVersion(1, 1, 1) < SemanticVersion(1, 1, 1) shouldBe false
-    SemanticVersion(1, 1, 1) < SemanticVersion(0, 1, 1) shouldBe false
-    SemanticVersion(1, 1, 1) < SemanticVersion(1, 0, 1) shouldBe false
-    SemanticVersion(1, 1, 1) < SemanticVersion(1, 1, 0) shouldBe false
-    SemanticVersion(1, 1, 1) < SemanticVersion(2, 1, 1) shouldBe true
-    SemanticVersion(1, 1, 1) < SemanticVersion(1, 2, 1) shouldBe true
-    SemanticVersion(1, 1, 1) < SemanticVersion(1, 1, 2) shouldBe true
-    SemanticVersion(1, 1, 1) < SemanticVersion(1, 1, 1, Some("SNAP")) shouldBe true
+    fromString("1.1.1") < fromString("1.1.1") shouldBe false
+    fromString("1.1.1") < fromString("0.1.1") shouldBe false
+    fromString("1.1.1") < fromString("1.0.1") shouldBe false
+    fromString("1.1.1") < fromString("1.1.0") shouldBe false
+    fromString("1.1.1") < fromString("2.1.1") shouldBe true
+    fromString("1.1.1") < fromString("1.2.1") shouldBe true
+    fromString("1.1.1") < fromString("1.1.2") shouldBe true
+    fromString("1.1.1") < fromString("1.1.1-SNAPSHOT") shouldBe true
   }
 
   @Test
   def testGreaterThenOrEqual(): Unit = {
-    SemanticVersion(1, 1, 1) >= SemanticVersion(1, 1, 1) shouldBe true
-    SemanticVersion(1, 1, 1) >= SemanticVersion(0, 1, 1) shouldBe true
-    SemanticVersion(1, 1, 1) >= SemanticVersion(1, 0, 1) shouldBe true
-    SemanticVersion(1, 1, 1) >= SemanticVersion(1, 1, 0) shouldBe true
-    SemanticVersion(1, 1, 1) >= SemanticVersion(2, 1, 1) shouldBe false
-    SemanticVersion(1, 1, 1) >= SemanticVersion(1, 2, 1) shouldBe false
-    SemanticVersion(1, 1, 1) >= SemanticVersion(1, 1, 2) shouldBe false
+    fromString("1.1.1") >= fromString("1.1.1") shouldBe true
+    fromString("1.1.1") >= fromString("0.1.1") shouldBe true
+    fromString("1.1.1") >= fromString("1.0.1") shouldBe true
+    fromString("1.1.1") >= fromString("1.1.0") shouldBe true
+    fromString("1.1.1") >= fromString("2.1.1") shouldBe false
+    fromString("1.1.1") >= fromString("1.2.1") shouldBe false
+    fromString("1.1.1") >= fromString("1.1.2") shouldBe false
   }
 
   @Test
   def testLesserThenOrEqual(): Unit = {
-    SemanticVersion(1, 1, 1) <= SemanticVersion(1, 1, 1) shouldBe true
-    SemanticVersion(1, 1, 1) <= SemanticVersion(0, 1, 1) shouldBe false
-    SemanticVersion(1, 1, 1) <= SemanticVersion(1, 0, 1) shouldBe false
-    SemanticVersion(1, 1, 1) <= SemanticVersion(1, 1, 0) shouldBe false
-    SemanticVersion(1, 1, 1) <= SemanticVersion(2, 1, 1) shouldBe true
-    SemanticVersion(1, 1, 1) <= SemanticVersion(1, 2, 1) shouldBe true
-    SemanticVersion(1, 1, 1) <= SemanticVersion(1, 1, 2) shouldBe true
+    fromString("1.1.1") <= fromString("1.1.1") shouldBe true
+    fromString("1.1.1") <= fromString("0.1.1") shouldBe false
+    fromString("1.1.1") <= fromString("1.0.1") shouldBe false
+    fromString("1.1.1") <= fromString("1.1.0") shouldBe false
+    fromString("1.1.1") <= fromString("2.1.1") shouldBe true
+    fromString("1.1.1") <= fromString("1.2.1") shouldBe true
+    fromString("1.1.1") <= fromString("1.1.2") shouldBe true
   }
   @Test
   def testBigVersionComparisons(): Unit = {
-    SemanticVersion(1, 1, 1) >= SemanticVersion(1, 200, 2) shouldBe false
-    SemanticVersion(3000, 231, 123) >= SemanticVersion(2991, 3231, 432) shouldBe true
+    fromString("1.1.1") >= fromString("1.200.2") shouldBe false
+    fromString("3000.231.123") >= fromString("2991.3231.432") shouldBe true
   }
   @Test
   def testSort(): Unit = {
@@ -143,7 +143,7 @@ class SemanticVersionTest extends BiopetTest {
     val sortedVersions = versions.sortBy(version =>
       fromString(version) match {
         case Some(semVer) => semVer
-        case _            => new SemanticVersion(0, 0, 0)
+        case _            => new SemanticVersion(0)
     })
     sortedVersions shouldBe Seq("0.8.0-alpha",
                                 "0.8.0-beta",
@@ -166,7 +166,7 @@ class SemanticVersionTest extends BiopetTest {
     val sortedVersions = versions.sortBy(version =>
       fromString(version) match {
         case Some(semVer) => semVer
-        case _            => new SemanticVersion(0, 0, 0)
+        case _            => new SemanticVersion(0)
     })
     sortedVersions shouldBe Seq(
       "2.82312123213.31231-XYZbladsa",


### PR DESCRIPTION
### Description

Test driven development was applied.

----

### Checklist (never delete this)

- [x] Each method/class/object/trait should have scaladocs
- [x] Added methods are unit tested
- [x] Test coverage may not drop
- [x] Documentation should be updated if required
